### PR TITLE
min/max requires arguments of the same kind

### DIFF
--- a/src/stepvis.cpp
+++ b/src/stepvis.cpp
@@ -1448,9 +1448,9 @@ void StepVis::drawPrimaryLabels(QPainter * painter, int effectiveHeight,
         skip = ceil(float(entitySpan) / total_labels);
     }
 
-    int start = std::max(floor(startEntity), 0.0);
+    int start = std::max(floor(startEntity), 0.0f);
     int end = std::min(ceil(startEntity + entitySpan),
-                       maxEntities - 1.0);
+                       maxEntities - 1.0f);
 
     int current = start;
     int offset = 0;

--- a/src/timelinevis.cpp
+++ b/src/timelinevis.cpp
@@ -310,9 +310,9 @@ void TimelineVis::drawEntityLabels(QPainter * painter, int effectiveHeight,
         skip = ceil(float(entitySpan) / total_labels);
     }
 
-    int start = std::max(floor(startEntity), 0.0);
+    int start = std::max(floor(startEntity), 0.0f);
     int end = std::min(ceil(startEntity + entitySpan),
-                       maxEntities - 1.0);
+                       maxEntities - 1.0f);
 
     if (trace->processingElements)
     {


### PR DESCRIPTION
required to build on macos (after fixing muster compilation cf https://github.com/LLNL/muster/pull/3)