### PR TITLE
Fix missing include

### DIFF
--- a/src/stepvis.cpp
+++ b/src/stepvis.cpp
@@ -41,6 +41,7 @@
 #include <QLocale>
 #include <QMouseEvent>
 #include <QWheelEvent>
+#include <QPainterPath> 
 
 #include "function.h"
 


### PR DESCRIPTION
This fixes a missing include when building with qt@5.15.2:
```
/tmp/tgy002/spack-stage/spack-stage-ravel-1.0.0-pmux276knfzoaia52kv4h5sia67pmkrf/spack-src/src/stepvis.cpp: In member function 'void StepVis::drawArc(QPainter*, QPointF*, QPointF*, int, bool)':
/tmp/tgy002/spack-stage/spack-stage-ravel-1.0.0-pmux276knfzoaia52kv4h5sia67pmkrf/spack-src/src/stepvis.cpp:1098:18: error: aggregate 'QPainterPath path' has incomplete type and cannot be defined
 1098 |     QPainterPath path;
```